### PR TITLE
Refactor sonar monitor range publishing

### DIFF
--- a/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/sensors/sonar_monitor.hpp
+++ b/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/sensors/sonar_monitor.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include <atomic>
-#include <mutex>
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -30,8 +29,7 @@ public:
 private:
   /// @brief The last recorded distance.
   std::atomic<double> distance = NAN;
-  std::mutex msg_mutex;
-  sensor_msgs::msg::Range range;
+  sensor_msgs::msg::Range range_msg_;
 
   // Publisher: distance/NAME
   rclcpp::Publisher<sensor_msgs::msg::Range>::SharedPtr sonar_pub;

--- a/mirte_telemetrix_cpp/src/sensors/sonar_monitor.cpp
+++ b/mirte_telemetrix_cpp/src/sensors/sonar_monitor.cpp
@@ -37,6 +37,13 @@ SonarMonitor::SonarMonitor(NodeData node_data, SonarData sonar_data)
                 std::placeholders::_2),
       rclcpp::ServicesQoS().get_rmw_qos_profile(), this->callback_group);
 
+  range_msg_.header.frame_id = this->frame_id;
+  range_msg_.radiation_type = sensor_msgs::msg::Range::ULTRASOUND;
+  range_msg_.field_of_view =
+      M_PI / 12.0; // 15 degrees, according to the HC-SR04 datasheet
+  range_msg_.min_range = this->min_range;
+  range_msg_.max_range = this->max_range;
+
   tmx->attach_sonar(
       sonar_data.trigger, sonar_data.echo,
       [this](auto pin, auto value) { this->data_callback(value); });
@@ -79,24 +86,14 @@ void SonarMonitor::data_callback(uint16_t value) {
 }
 
 void SonarMonitor::update() {
-  auto msg =
-      sensor_msgs::build<sensor_msgs::msg::Range>()
-          .header(this->get_header())
-          .radiation_type(sensor_msgs::msg::Range::ULTRASOUND)
-          .field_of_view(M_PI /
-                         12.0) // 15 degrees, according to the HC-SR04 datasheet
-          .min_range(this->min_range)
-          .max_range(this->max_range)
-          .range(this->distance);
+  range_msg_.header.stamp = this->nh->now();
+  range_msg_.range = this->distance;
 
-  this->sonar_pub->publish(msg);
-  const std::lock_guard<std::mutex> lock(msg_mutex);
-  this->range = msg;
+  this->sonar_pub->publish(range_msg_);
 }
 
 void SonarMonitor::service_callback(
     const mirte_msgs::srv::GetRange::Request::ConstSharedPtr req,
     mirte_msgs::srv::GetRange::Response::SharedPtr res) {
-  const std::lock_guard<std::mutex> lock(msg_mutex);
-  res->range = this->range;
+  res->range = range_msg_;
 }


### PR DESCRIPTION
## Summary
- store sonar readings in persistent `sensor_msgs::msg::Range`
- update timestamp and range only before publishing
- simplify service callback by returning stored range message